### PR TITLE
Add unit declarator to class and module declarations

### DIFF
--- a/lib/SCGI.pm6
+++ b/lib/SCGI.pm6
@@ -1,4 +1,4 @@
-class SCGI;
+unit class SCGI;
 
 use SCGI::Connection;
 

--- a/lib/SCGI/Connection.pm6
+++ b/lib/SCGI/Connection.pm6
@@ -1,4 +1,4 @@
-class SCGI::Connection;
+unit class SCGI::Connection;
 
 use SCGI::Request;
 use SCGI::Response;

--- a/lib/SCGI/Constants.pm6
+++ b/lib/SCGI/Constants.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module SCGI::Constants;
+unit module SCGI::Constants;
 
 constant CRLF is export = "\x0D\x0A";
 constant SEP  is export = "\0";

--- a/lib/SCGI/Errors.pm6
+++ b/lib/SCGI/Errors.pm6
@@ -1,4 +1,4 @@
-class SCGI::Errors;
+unit class SCGI::Errors;
 
 use SCGI::Constants;
 

--- a/lib/SCGI/Request.pm6
+++ b/lib/SCGI/Request.pm6
@@ -1,4 +1,4 @@
-class SCGI::Request;
+unit class SCGI::Request;
 
 use Netstring;
 use SCGI::Constants;

--- a/lib/SCGI/Response.pm6
+++ b/lib/SCGI/Response.pm6
@@ -1,4 +1,4 @@
-class SCGI::Response;
+unit class SCGI::Response;
 
 use HTTP::Status;
 use SCGI::Constants;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.