### PR TITLE
Add multithread handling.

### DIFF
--- a/lib/SCGI/Request.pm6
+++ b/lib/SCGI/Request.pm6
@@ -52,7 +52,8 @@ method parse ()
     populate-psgi-env(%.env, :input($.input), :errors($.connection.err), 
         :psgi-classic($.connection.parent.PSGI), 
         :p6sgi($.connection.parent.P6SGI),
-        :url-scheme($scheme)
+        :url-scheme($scheme),
+        :multithread($.connection.parent.multithread)
     );
   }
 


### PR DESCRIPTION
Apparently you don't even need IO::Socket::Async for this :grinning: 

Was originally using the label `async` but changed to `multithread` to follow P6W spec.