### PR TITLE
Docs example for raw server changed so that it doesn't error any more…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ or using a raw HTTP output instead of PSGI. Here's an example doing both:
 ```perl
   use SCGI;
 
-  my $scgi = SCGI.new( :port(8118), :!PSGI );
+  my $scgi = SCGI.new( :port(8118), :!PSGI, :!P6SGI );
   while (my $connection = $scgi.accept())
   {
     my $request = $connection.request;

--- a/examples/alternative.p6
+++ b/examples/alternative.p6
@@ -6,7 +6,7 @@
 ###############################################################################
 use SCGI;
 
-my $scgi = SCGI.new( :port(8118), :!PSGI );
+my $scgi = SCGI.new( :port(8118), :!PSGI, :!P6SGI );
 
 say "Starting raw SCGI server.";
 


### PR DESCRIPTION
…. You also need to exclude both P6SGI and PSGI

This extra false flag will let the example for the raw server actually run. My guess is that support for P6SGI was added later, and the readme's never updated to take out that new PSGI stuff as well. This also resolves the issue about the example failing.